### PR TITLE
Add support for different push notification types

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -91,6 +91,15 @@ class Payload implements \JsonSerializable
      */
     private $customValues;
 
+    /**
+     * Push notification type
+     *
+     * https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947607
+     *
+     * @var string
+     */
+    private $pushType;
+
     protected function __construct()
     {
     }
@@ -300,6 +309,27 @@ class Payload implements \JsonSerializable
         }
 
         return $this->customValues[$key];
+    }
+
+    /**
+     * Set push type for Payload.
+     *
+     * @param string $pushType
+     * @return Payload
+     */
+    public function setPushType($pushType) {
+        $this->pushType = $pushType;
+
+        return $this;
+    }
+
+    /**
+     * Get push type for Payload.
+     *
+     * @return string
+     */
+    public function getPushType() {
+        return $this->pushType;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -235,13 +235,14 @@ class Request
         if (!empty($notification->getCollapseId())) {
             $this->headers[self::HEADER_APNS_COLLAPSE_ID ] = $notification->getCollapseId();
         }
-        
-        // new header required to support iOS 13
-        
-        $this->headers[self::HEADER_APNS_PUSH_TYPE] = 'alert';
-        
-        if ($notification->getPayload()->isContentAvailable()) {
+        // if the push type was set when the payload was created then it will set that as a push type,
+        // otherwise we would do our best in order to guess what push type is.
+        if (!empty($notification->getPayload()->getPushType())) {
+            $this->headers[self::HEADER_APNS_PUSH_TYPE] = $notification->getPayload()->getPushType();
+        } else if ($notification->getPayload()->isContentAvailable()) {
             $this->headers[self::HEADER_APNS_PUSH_TYPE] = 'background';
+        } else {
+            $this->headers[self::HEADER_APNS_PUSH_TYPE] = 'alert';
         }
     }
 }


### PR DESCRIPTION
On Payload.php:
- Add private var $pushType
- Add getter and setter {set,get}PushType, in case we want one of the
new different pushTypes we can call that method and set the push type

On Request.php

- Change of the logic for detecting the type of push notifications, we
are giving the priority first if the
`$notification->getPayload()->getPushType()` is set, then it will use
this header (useful for voip notifications), otherwise it will use the
same logic we were using before